### PR TITLE
Update contact email in administratives page

### DIFF
--- a/pages/administratives.vue
+++ b/pages/administratives.vue
@@ -57,7 +57,7 @@
         </div>
         <div class="admin-segment something-missing">
           <p>Etwas fehlt oder ist falsch?</p>
-          <FancyLink to="mailto:admin@pfadischenkenberg.ch">Schreib uns eine Mail</FancyLink>
+          <FancyLink to="mailto:it@pfadischenkenberg.ch">Schreib uns eine Mail</FancyLink>
         </div>
       </div>
     </main>


### PR DESCRIPTION
Changed the contact email address from admin@pfadischenkenberg.ch to it@pfadischenkenberg.ch in the administratives page for more accurate correspondence.