### PR TITLE
Improve dropdown responsiveness for medium screens

### DIFF
--- a/components/NavDropdownElement.vue
+++ b/components/NavDropdownElement.vue
@@ -68,6 +68,11 @@ function closeDropdown() {
     width: 100%;
 
 
+    @media screen and (max-width: var.$screen-size-medium) {
+      position: static;
+      width: 100%;
+    }
+
     @media screen and (max-width: var.$screen-size-small) {
       min-width: 50%;
     }
@@ -79,6 +84,11 @@ function closeDropdown() {
       background-color: rgba(var.$tan-hide-50, 0.2);
       backdrop-filter: blur(5px);
       -webkit-backdrop-filter: blur(5px);
+
+      @media screen and (max-width: var.$screen-size-medium) {
+        background-color: rgba(var.$tan-hide-50, 0.8);
+        padding: 0.5rem 0;
+      }
 
       & > * > * {
         color: var.$burnt-sienna-700;


### PR DESCRIPTION
Added media queries to adjust dropdown position, width, and background styling for screens at or below the medium breakpoint, enhancing mobile and tablet usability.


https://github.com/user-attachments/assets/0e7922a1-0edc-4ccf-98f3-b6286b766e24

