### PR TITLE
Add donation Paylink button to footer

### DIFF
--- a/components/DefaultFooter.vue
+++ b/components/DefaultFooter.vue
@@ -15,11 +15,11 @@
             <li>
               <NuxtLink to="/impressum">Impressum</NuxtLink>
             </li>
+            <li class="footer-donation-item">
+              <div id="rnw-paylink-button-pkpyt"></div>
+            </li>
           </ul>
         </nav>
-        <div class="footer-donation">
-          <div id="rnw-paylink-button-pkpyt"></div>
-        </div>
         <NuxtLink class="footer-link-instagram" to="https://www.instagram.com/pfadi_schenkenberg/" target="_blank"
                   title="Link zum Schenkenberg Instagram Account" />
       </div>
@@ -108,12 +108,13 @@ onMounted(() => {
             text-decoration: underline;
           }
         }
-      }
-    }
 
-    .footer-donation {
-      zoom: 0.55;
-      flex-shrink: 0;
+        &.footer-donation-item {
+          zoom: 0.55;
+          display: flex;
+          align-items: center;
+        }
+      }
     }
 
     .footer-link-instagram {
@@ -190,6 +191,10 @@ footer::before {
 
       .footer-link-instagram {
         display: none;
+      }
+
+      ul .footer-donation-item {
+        zoom: 0.75;
       }
     }
 

--- a/components/DefaultFooter.vue
+++ b/components/DefaultFooter.vue
@@ -17,6 +17,9 @@
             </li>
           </ul>
         </nav>
+        <div class="footer-donation">
+          <div id="rnw-paylink-button-pkpyt"></div>
+        </div>
         <NuxtLink class="footer-link-instagram" to="https://www.instagram.com/pfadi_schenkenberg/" target="_blank"
                   title="Link zum Schenkenberg Instagram Account" />
       </div>
@@ -28,6 +31,24 @@
 
 <script setup lang="ts">
 const year = new Date().getFullYear();
+
+onMounted(() => {
+  const script = document.createElement('script');
+  script.type = 'module';
+  script.textContent = `
+    import { PaylinkButton } from "https://unpkg.com/@raisenow/paylink-button@2/dist/PaylinkButton.js";
+    PaylinkButton.render("#rnw-paylink-button-pkpyt", {
+      "solution-id": "pkpyt",
+      "size": "small",
+      "width": "dynamic",
+      "icon": "gift",
+      "label": "Unterstütze uns!",
+      "border-radius": "9px",
+      "background-color": "#444444",
+    });
+  `;
+  document.head.appendChild(script);
+});
 </script>
 
 <style lang="scss" scoped>
@@ -72,7 +93,7 @@ const year = new Date().getFullYear();
 
     ul {
       display: flex;
-      align-items: end;
+      align-items: center;
       justify-content: center;
       gap: 2rem;
 
@@ -88,6 +109,11 @@ const year = new Date().getFullYear();
           }
         }
       }
+    }
+
+    .footer-donation {
+      zoom: 0.55;
+      flex-shrink: 0;
     }
 
     .footer-link-instagram {
@@ -150,7 +176,6 @@ footer::before {
     align-items: center;
 
     gap: 0;
-
 
     .footer-logo {
       position: initial;


### PR DESCRIPTION
Add a Raisenow Paylink donation button to the site footer. components/DefaultFooter.vue now includes a .footer-donation container with an element (#rnw-paylink-button-pkpyt) and an onMounted hook that injects a module script to import and render PaylinkButton from the CDN (solution-id: pkpyt) with a localized label and styling. Also adjust footer layout: align-items set to center for link list and add .footer-donation CSS (zoom and flex-shrink). Minor whitespace/trailing-newline cleanup included.